### PR TITLE
chore(package): upgrade to version 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mt-web-icons",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "main": "react/Icon/index.js",
   "types": "react/Icon/index.d.ts",


### PR DESCRIPTION
- Upgrade product version to 0.1.2 to resolve third party products to pick wrong version when `yarn install moneytree/mt-web-icons`