### PR TITLE
fix(icon): default size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mt-web-icons",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "main": "react/Icon/cjs/index.js",
   "module": "react/Icon/esm/index.js",

--- a/templates/IconComponent.jsx
+++ b/templates/IconComponent.jsx
@@ -21,7 +21,7 @@ function getModule(name) {
 }
 
 function renderFallback(props) {
-  const { width = 20, height = 20 } = props;
+  const { width = 24, height = 24 } = props;
   const fallbackProps = {
     ...props,
     width,


### PR DESCRIPTION
Set default fallback icon size to 24px since the original icon will render at 24px.