### PR TITLE
chore(version): bump version to 0.1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ make sure replace these folder & files
     - replace the folder `/fonts` with unzip folder `/fonts`
     - replace the file `/css/style.css` with unzip file `/style.css`
     - replace the file `/selection.json` with unzip file `/selection.json`
+10. In `package.json` increment the version
+11. create a release in github
 
 ### Test the new icon it's work on local.
 1. Under the mt-web-icon run

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mt-web-icons",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "main": "react/Icon/cjs/index.js",
   "module": "react/Icon/esm/index.js",


### PR DESCRIPTION
I forgot to bump the version when I added the previous icon.