### PR TITLE
Add cooldown for dependabot to prevent too-new versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 10
+    ignore:
+      # ignore automatic major updates for all dependencies
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
## Summary

Adds a `dependabot.yml` file and configures it to wait 10 days after release before suggesting a new package, bringing it inline with our yarn settings.
